### PR TITLE
Add mouse contro, add option for ytdl path

### DIFF
--- a/youtube-quality.conf
+++ b/youtube-quality.conf
@@ -1,21 +1,22 @@
 # KEY BINDINGS
 
-# invoke or dismiss the quality menu
-toggle_video_menu_binding=ctrl+f
-toggle_audio_menu_binding=alt+f
-close_menu_binding=ESC
 # move the menu cursor up
-up_binding=UP
+up_binding=UP WHEEL_UP
 # move the menu cursor down
-down_binding=DOWN
+down_binding=DOWN WHEEL_DOWN
 # select menu entry
-select_binding=ENTER
+select_binding=ENTER MBTN_LEFT
+# close menu
+close_menu_binding=ESC MBTN_RIGHT
+
+# youtube-dl version(could be youtube-dl or yt-dlp, or something else)
+ytdl_ver=yt-dlp
 
 # formatting / cursors
-selected_and_active=▶ - 
+selected_and_active=▶  - 
 selected_and_inactive=●  - 
 unselected_and_active=▷ - 
-unselected_and_inactive=○  - 
+unselected_and_inactive=○ - 
 
 # font size scales by window, if false requires larger font and padding sizes
 scale_playlist_by_window=yes


### PR DESCRIPTION
Add mouse control
Delete key binding of "escape", It will break the video menu key binding
Change the binding of the main menu key. Now it should be binding in input.conf

Merge https://github.com/jgreco/mpv-youtube-quality/pull/29 : adds variable for changing youtube-dl service, like yt-dlp.